### PR TITLE
Fix crash caused by miss match between

### DIFF
--- a/Sources/IBPCollectionViewCompositionalLayout/IBPUICollectionViewCompositionalLayout.m
+++ b/Sources/IBPCollectionViewCompositionalLayout/IBPUICollectionViewCompositionalLayout.m
@@ -425,8 +425,7 @@
             layoutAttributes.zIndex = decorationItem.zIndex;
 
             layoutAttributes.frame = frame;
-            NSIndexPath *indexPath = [NSIndexPath indexPathForItem:0 inSection:sectionIndex];
-            cachedDecorationAttributes[indexPath] = layoutAttributes;
+            cachedDecorationAttributes[[NSString stringWithFormat:@"%@-%zd-%d", decorationItem.elementKind, sectionIndex, 0]] = layoutAttributes;
         }
 
         CGRect insetsContentFrame = contentFrame;


### PR DESCRIPTION
cache keys for decoration view attributes